### PR TITLE
Always flush() between write and read

### DIFF
--- a/zstd_asgi/__init__.py
+++ b/zstd_asgi/__init__.py
@@ -180,12 +180,11 @@ class ZstdResponder:
             more_body = message.get("more_body", False)
 
             self.zstd_file.write(body)
+            self.zstd_file.flush(zstandard.FLUSH_FRAME)
+            message["body"] = self.zstd_buffer.getvalue()
             if not more_body:
-                self.zstd_file.flush(zstandard.FLUSH_FRAME)
-                message["body"] = self.zstd_buffer.getvalue()
                 self.zstd_file.close()
             else:
-                message["body"] = self.zstd_buffer.getvalue()
                 self.zstd_buffer.seek(0)
                 self.zstd_buffer.truncate()
 


### PR DESCRIPTION
Messages received after `started` were not being flushed until the very last message (when `not more_body`).

Instead, we should always flush() between a write and a read.

Without this, we were observing behavior that didn't work for server-sent events: the first message would be delivered immediately, and then all subsequent messages would be delivered all in one go when the last message arrives.

See similar change in GZIpMiddleware at https://github.com/encode/starlette/pull/2753