### PR TITLE
Add `q-factor` parsing feature

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -214,3 +214,109 @@ def test_zstd_avoids_double_encoding(test_client_factory):
         response.headers["Content-Length"]
         == response.headers["x-gzipped-content-length"]
     )
+
+
+@pytest.mark.parametrize(
+    "accept_encoding, gzip_fallback, expected_encoding",
+    [
+        # 1. zstd has higher q-factor than gzip
+        ("zstd;q=1.0, gzip;q=0.5", True, "zstd"),
+        
+        # 2. gzip has higher q-factor than zstd (gzip_fallback=True)
+        ("zstd;q=0.5, gzip;q=1.0", True, "gzip"),
+        
+        # 3. zstd is preferred when q-factors are equal (tests CODING_PRIORITIES)
+        ("zstd;q=0.8, gzip;q=0.8", True, "zstd"),
+        ("gzip;q=0.8, zstd;q=0.8", True, "zstd"),
+        
+        # 4. Unsupported 'br' has highest q, fallback to zstd
+        ("br;q=1.0, zstd;q=0.9, gzip;q=0.8", True, "zstd"),
+        
+        # 5. zstd is forbidden (q=0) -> select gzip
+        ("zstd;q=0, gzip;q=1.0", True, "gzip"),
+        
+        # 6. Both zstd and gzip are forbidden -> select identity (no compression)
+        ("zstd;q=0, gzip;q=0", True, "identity"),
+        
+        # 7. Wildcard (*) matches zstd/gzip (zstd preferred)
+        ("br;q=1.0, *;q=0.5", True, "zstd"),
+        
+        # 8. Wildcard, zstd forbidden -> select gzip
+        ("zstd;q=0, *;q=0.5", True, "gzip"),
+        
+        # 9. identity (no compression) is preferred
+        ("zstd;q=0.1, identity;q=0.5", True, "identity"),
+        
+        # 10. identity is explicitly forbidden -> select zstd
+        ("identity;q=0, zstd;q=0.5", True, "zstd"),
+        
+        # --- Scenarios with gzip_fallback=False ---
+        
+        # 11. gzip preferred but fallback=False -> select zstd
+        ("zstd;q=0.5, gzip;q=1.0", False, "zstd"),
+        
+        # 12. zstd forbidden, gzip preferred, but fallback=False -> select identity
+        ("zstd;q=0, gzip;q=1.0", False, "identity"),
+        
+        # 13. Only gzip available, but fallback=False -> select identity
+        ("gzip;q=1.0", False, "identity"),
+    ],
+)
+def test_respect_q_factors(
+    test_client_factory, accept_encoding, gzip_fallback, expected_encoding
+):
+    """
+    Tests that q-factor negotiation works correctly when respect_q_factors=True.
+    """
+    def homepage(request):
+        return PlainTextResponse("x" * 4000, status_code=200)
+
+    app = Starlette(routes=[Route("/", homepage)])
+    app.add_middleware(
+        ZstdMiddleware,
+        respect_q_factors=True,  # <-- The core flag for this test
+        gzip_fallback=gzip_fallback
+    )
+
+    client = test_client_factory(app)
+    response = client.get("/", headers={"accept-encoding": accept_encoding})
+    
+    assert response.status_code == 200
+    
+    if expected_encoding == "zstd":
+        assert response.headers["Content-Encoding"] == "zstd"
+        assert decompressed_response(response) == b"x" * 4000
+        assert int(response.headers["Content-Length"]) < 4000
+    elif expected_encoding == "gzip":
+        # TestClient (httpx) decompresses gzip automatically.
+        assert response.headers["Content-Encoding"] == "gzip"
+        assert response.text == "x" * 4000 
+        assert int(response.headers["Content-Length"]) < 4000
+    elif expected_encoding == "identity":
+        assert "Content-Encoding" not in response.headers
+        assert response.text == "x" * 4000
+        assert int(response.headers["Content-Length"]) == 4000
+
+
+def test_q_factors_ignored_by_default(test_client_factory):
+    """
+    Tests that when respect_q_factors=False (default),
+    q-factors are ignored and zstd is chosen if present.
+    """
+    def homepage(request):
+        return PlainTextResponse("x" * 4000, status_code=200)
+
+    app = Starlette(routes=[Route("/", homepage)])
+    # Do not set respect_q_factors flag (defaults to False)
+    app.add_middleware(ZstdMiddleware, gzip_fallback=True) 
+
+    client = test_client_factory(app)
+    
+    # gzip is preferred (q=1.0), but 'zstd' is present in the header
+    headers = {"accept-encoding": "zstd;q=0.5, gzip;q=1.0"}
+    response = client.get("/", headers=headers)
+    
+    # Default logic ('zstd' in header) should run and select zstd
+    assert response.status_code == 200
+    assert response.headers["Content-Encoding"] == "zstd"
+    assert decompressed_response(response) == b"x" * 4000

--- a/zstd_asgi/headers.py
+++ b/zstd_asgi/headers.py
@@ -1,0 +1,111 @@
+"""
+HTTP Accept-Encoding header parsing and negotiation utilities.
+"""
+from functools import lru_cache
+from typing import Literal
+
+# Defines the internal priority for encodings we recognize.
+# Lower numbers are preferred when q-factors are equal.
+# "zstd" > "gzip" > "identity" > "*"
+CODING_PRIORITIES: dict[str, int] = {
+    "zstd": 0,
+    "gzip": 1,
+    "identity": 998,  # 'identity' means no compression
+    "*": 999,         # '*' means any other encoding
+}
+
+# Defines the clear return types for the encoding selection
+SupportedEncoding = Literal["zstd", "gzip", "identity"]
+
+
+def parse_part(part: str) -> tuple[float, int, str] | None:
+    """
+    Parses a single part of the 'Accept-Encoding' header (e.g., "gzip;q=0.8").
+    Returns a tuple of (q-factor, priority, encoding_name) or None if invalid.
+    """
+    part = part.strip()
+    if not part:
+        return None
+
+    components = part.split(";")
+    coding_name = components[0].strip()
+
+    if coding_name not in CODING_PRIORITIES:
+        # Ignore encodings we don't recognize or support (e.g., "br", "deflate")
+        return None
+
+    priority = CODING_PRIORITIES[coding_name]
+    q_val = 1.0  # Default q-factor is 1.0 per RFC
+
+    # Find the "q=" parameter, if it exists
+    for param in components[1:]:
+        param = param.strip()
+        if param.startswith("q="):
+            try:
+                q_val = float(param[2:])
+            except ValueError:
+                q_val = 0.0  # A malformed q-factor (e.g., "q=foo") means "not acceptable"
+            break
+    
+    if q_val <= 0:
+        return None  # q=0 means the client explicitly forbids this encoding
+    
+    if q_val > 1.0:
+        q_val = 1.0  # q-factor cannot exceed 1.0
+
+    return (q_val, priority, coding_name)
+
+
+@lru_cache(maxsize=128)
+def get_preferred_encoding(
+    accept_encoding: str, 
+    gzip_fallback: bool
+) -> SupportedEncoding:
+    """
+    Parses the 'Accept-Encoding' header string and returns the
+    highest-priority encoding that the server supports ("zstd", "gzip", or "identity").
+    
+    Results are LRU-cached for performance.
+    """
+    options: list[tuple[float, int, str]] = []
+    
+    # 1. Parse the header into a list of valid, supported options
+    for part_str in accept_encoding.split(","):
+        parsed = parse_part(part_str)
+        if parsed:
+            options.append(parsed)
+        
+    # 2. Sort the options:
+    options.sort(key=lambda p: (-p[0], p[1]))
+
+    # 3. Find the first supported encoding in the sorted list
+    for q, priority, name in options:
+        if name == "zstd":
+            return "zstd"
+        
+        if name == "gzip":
+            if gzip_fallback:
+                return "gzip"
+            # If gzip_fallback=False, skip gzip and continue
+        
+        if name == "identity":
+            return "identity"  # No compression
+        
+        if name == "*":
+            # The wildcard "*" matches any encoding not already listed.
+            # At this point, we apply server preference (zstd > gzip)
+            # unless those encodings were explicitly forbidden.
+            
+            if "zstd;q=0" not in accept_encoding.replace(" ", ""):
+                return "zstd"
+            
+            if gzip_fallback and "gzip;q=0" not in accept_encoding.replace(" ", ""):
+                return "gzip"
+            
+            # If both are banned or gzip is not a fallback, use identity
+            return "identity"
+
+    # If no options were parsed (e.g., only "br;q=1.0" was sent)
+    # or no supported encodings were found, default to no compression.
+    # This is the correct fallback behavior.
+    return "identity"

--- a/zstd_asgi/headers.py
+++ b/zstd_asgi/headers.py
@@ -2,7 +2,7 @@
 HTTP Accept-Encoding header parsing and negotiation utilities.
 """
 from functools import lru_cache
-from typing import Literal
+from typing import Literal, Union, Tuple
 
 # Defines the internal priority for encodings we recognize.
 # Lower numbers are preferred when q-factors are equal.
@@ -18,7 +18,7 @@ CODING_PRIORITIES: dict[str, int] = {
 SupportedEncoding = Literal["zstd", "gzip", "identity"]
 
 
-def parse_part(part: str) -> tuple[float, int, str] | None:
+def parse_part(part: str) -> Union[Tuple[float, int, str], None]:
     """
     Parses a single part of the 'Accept-Encoding' header (e.g., "gzip;q=0.8").
     Returns a tuple of (q-factor, priority, encoding_name) or None if invalid.


### PR DESCRIPTION
This PR introduces optional support for `q-factor` (quality value) negotiation for the Accept-Encoding header, aligning the middleware's behavior more closely with [RFC 9110 (Section 12.5.3)](https://www.google.com/search?q=https://www.rfc-editor.org/rfc/rfc9110.html%23field.accept-encoding).


## Key Changes
- New Flag: Introduces a `respect_q_factors: bool = False` argument to the `ZstdMiddleware` constructor.
- Backward Compatibility: The default behavior (False) is unchanged, ensuring zero performance impact or breaking changes for existing users.
- Opt-In Logic: When `respect_q_factors=True`, the middleware uses a new header-parsing utility to select the best encoding (`zstd`, `gzip`, or `identity`) based on the client's `q` values.
- Performance: The new `get_preferred_encoding` function is cached with `@lru_cache(maxsize=128)` to mitigate any performance overhead from parsing the same header strings on subsequent requests.


Resolve: #12 